### PR TITLE
Update cop in preparation for rubocop 1.0

### DIFF
--- a/active_record_callbacks_cop.gemspec
+++ b/active_record_callbacks_cop.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "appraisal"
 
-  spec.add_dependency "rubocop", ">= 0.72.0" # just copied rubocop-rails' dependency constraint for this
+  spec.add_dependency "rubocop", ">= 0.87.0"
 end

--- a/lib/active_record_callbacks_cop/cop.rb
+++ b/lib/active_record_callbacks_cop/cop.rb
@@ -1,40 +1,40 @@
 require 'rubocop'
 
 module ActiveRecordCallbacksCop
-  class Cop < RuboCop::Cop::Cop
+  class Cop < RuboCop::Cop::Base
     def self.cop_name
       "ActiveRecordCallbacks"
     end
 
     MSG = "Don't use ActiveRecord callbacks to add logic to your database interactions."
+    RESTRICT_ON_SEND = %i[
+      before_validation after_validation
+      before_save around_save after_save
+      before_create around_create after_create
+      before_destroy around_destroy after_destroy
+      after_commit
+      after_create_commit after_update_commit after_destroy_commit
+      after_rollback
+      after_touch
+    ].freeze
+
+    def_node_matcher :active_record?, <<~PATTERN
+      {
+        (const {nil? cbase} :ApplicationRecord)
+        (const (const {nil? cbase} :ActiveRecord) :Base)
+      }
+    PATTERN
 
     def on_send(node)
-      return unless callback_names.include?(node.method_name)
-      return unless node.parent.class_type? &&
-        node.parent.parent_class &&
-        parent_class_names.include?(node.parent.parent_class.const_name)
+      return unless inherit_active_record_base?(node)
 
-      add_offense(node)
+      add_offense(node.loc.selector)
     end
 
     private
 
-    def parent_class_names
-      %w(ActiveRecord::Base ApplicationRecord)
-    end
-
-    # TODO: maybe there should be separate cops for groups of callbacks?
-    def callback_names
-      %i(
-        before_validation after_validation
-        before_save around_save after_save
-        before_create around_create after_create
-        before_destroy around_destroy after_destroy
-        after_commit
-        after_create_commit after_update_commit after_destroy_commit
-        after_rollback
-        after_touch
-      )
+    def inherit_active_record_base?(node)
+      node.each_ancestor(:class).any? { |class_node| active_record?(class_node.parent_class) }
     end
   end
 end

--- a/lib/active_record_callbacks_cop/version.rb
+++ b/lib/active_record_callbacks_cop/version.rb
@@ -1,3 +1,3 @@
 module ActiveRecordCallbacksCop
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
This will fix the deprecation warning:

```
warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead. For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.
```